### PR TITLE
Add complex real-world pandas examples

### DIFF
--- a/playground/example_energy_anomaly_monitoring.html
+++ b/playground/example_energy_anomaly_monitoring.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>tsb — Energy Anomaly Monitoring — Examples</title>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --accent: #58a6ff;
+      --green: #3fb950;
+      --orange: #d29922;
+      --red: #f85149;
+      --font-mono: "Cascadia Code", "Fira Code", "JetBrains Mono", monospace;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: system-ui, -apple-system, sans-serif;
+      line-height: 1.6;
+      padding: 2rem;
+      max-width: 920px;
+      margin: 0 auto;
+    }
+    a { color: var(--accent); }
+    h1 { color: var(--accent); margin-bottom: 0.5rem; }
+    h2 { margin-top: 0; margin-bottom: 0.5rem; font-size: 1.25rem; }
+    p  { color: #8b949e; margin-bottom: 1rem; }
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.875em;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.3rem;
+      padding: 0.1rem 0.4rem;
+    }
+    .back { margin-bottom: 1.25rem; display: inline-block; }
+    .scenario {
+      background: rgba(88, 166, 255, 0.06);
+      border-left: 3px solid var(--accent);
+      padding: 0.75rem 1rem;
+      border-radius: 0 0.4rem 0.4rem 0;
+      margin: 1rem 0 1.5rem;
+      color: #c9d1d9;
+    }
+    .scenario strong { color: var(--accent); }
+    #playground-loading {
+      position: fixed; inset: 0;
+      background: rgba(13, 17, 23, 0.92);
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      z-index: 1000; gap: 1rem;
+    }
+    .spinner {
+      width: 40px; height: 40px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    #playground-status { color: #8b949e; font-size: 0.95rem; }
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .section p { margin-bottom: 0.75rem; }
+    .playground-block { margin-top: 0.75rem; }
+    .playground-header {
+      display: flex; align-items: center; justify-content: space-between;
+      background: #1c2128; border: 1px solid var(--border);
+      border-bottom: none; border-radius: 0.5rem 0.5rem 0 0;
+      padding: 0.4rem 0.75rem;
+    }
+    .playground-label {
+      font-size: 0.75rem; color: #8b949e;
+      text-transform: uppercase; letter-spacing: 0.05em;
+    }
+    .playground-actions { display: flex; gap: 0.5rem; }
+    .playground-actions button {
+      background: transparent; color: var(--accent);
+      border: 1px solid var(--border); border-radius: 0.35rem;
+      padding: 0.25rem 0.7rem; font-size: 0.8rem;
+      cursor: pointer; font-family: system-ui, sans-serif;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .playground-actions button:hover:not(:disabled) {
+      background: rgba(88, 166, 255, 0.1);
+      border-color: var(--accent);
+    }
+    .playground-actions button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .playground-run { font-weight: 600; }
+    .playground-editor {
+      display: block; width: 100%; min-height: 80px;
+      background: #0d1117; color: var(--text);
+      border: 1px solid var(--border);
+      border-top: none; border-bottom: none;
+      padding: 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.875rem; line-height: 1.55;
+      resize: vertical; outline: none;
+      tab-size: 2; white-space: pre; overflow-x: auto;
+    }
+    .playground-editor:focus {
+      border-color: var(--accent);
+      box-shadow: inset 0 0 0 1px var(--accent);
+    }
+    .playground-output {
+      background: #1c2333;
+      border: 1px solid var(--border);
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.85rem; color: #8b949e;
+      white-space: pre-wrap; min-height: 2rem;
+      word-break: break-word;
+    }
+    .playground-output.active { color: var(--green); border-color: var(--green); }
+    .playground-output.error { color: var(--red); border-color: var(--red); }
+    .playground-hint {
+      font-size: 0.75rem; color: #484f58;
+      margin-top: 0.35rem; text-align: right;
+    }
+    footer {
+      text-align: center; padding: 2rem 0;
+      color: #8b949e; font-size: 0.85rem;
+      border-top: 1px solid var(--border);
+      margin-top: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div id="playground-loading">
+    <div class="spinner"></div>
+    <div id="playground-status">Initializing playground…</div>
+  </div>
+
+  <a class="back" href="examples.html">← Back to examples</a>
+  <h1>⚡ Energy Anomaly Monitoring</h1>
+  <div class="scenario"><strong>Scenario:</strong> A facilities analytics team monitors smart-meter readings across several buildings, normalizes consumption by size and weather, and turns unusual spikes into maintenance tickets.</div>
+  <p>Skills you'll use: <code>merge</code>, derived intensity metrics, rolling baselines, filters, <code>nlargestDataFrame</code>, <code>groupby().agg()</code>, and pivot-table alert summaries.</p>
+
+  <div class="section">
+    <h2>1 · Enrich smart-meter readings</h2>
+    <p>Join telemetry with building metadata and normalize energy use by floor area and occupancy.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, merge } from "tsb";
+
+const readings = DataFrame.fromRecords([
+  { hour: "08:00", building_id: "B01", meter: "main", kwh: 72, outdoor_c: 19, occupancy: 118 },
+  { hour: "08:00", building_id: "B02", meter: "main", kwh: 54, outdoor_c: 18, occupancy: 76 },
+  { hour: "08:00", building_id: "B03", meter: "main", kwh: 91, outdoor_c: 22, occupancy: 140 },
+  { hour: "09:00", building_id: "B01", meter: "main", kwh: 78, outdoor_c: 21, occupancy: 132 },
+  { hour: "09:00", building_id: "B02", meter: "main", kwh: 58, outdoor_c: 20, occupancy: 82 },
+  { hour: "09:00", building_id: "B03", meter: "main", kwh: 116, outdoor_c: 24, occupancy: 148 },
+  { hour: "10:00", building_id: "B01", meter: "main", kwh: 84, outdoor_c: 22, occupancy: 138 },
+  { hour: "10:00", building_id: "B02", meter: "main", kwh: 61, outdoor_c: 22, occupancy: 89 },
+  { hour: "10:00", building_id: "B03", meter: "main", kwh: 143, outdoor_c: 26, occupancy: 151 },
+]);
+const buildings = DataFrame.fromRecords([
+  { building_id: "B01", campus: "North", sqft: 42000, system: "mixed-use" },
+  { building_id: "B02", campus: "North", sqft: 28000, system: "office" },
+  { building_id: "B03", campus: "South", sqft: 51000, system: "lab" },
+]);
+
+const enriched = merge(readings, buildings, { on: "building_id", how: "left" }).assign({
+  kwh_per_ksqft: (df) =&gt; df.col("kwh").div(df.col("sqft")).mul(1000),
+  occupant_kwh: (df) =&gt; df.col("kwh").div(df.col("occupancy")),
+  weather_adjusted_kwh: (df) =&gt; df.col("kwh").sub(df.col("outdoor_c").sub(18).mul(1.5)),
+});
+console.log(enriched.select(["hour", "building_id", "campus", "kwh", "kwh_per_ksqft", "occupant_kwh", "weather_adjusted_kwh"]).toString());
+
+const campusSummary = enriched
+  .groupby("campus")
+  .agg({ kwh: "sum", kwh_per_ksqft: "mean", occupant_kwh: "mean" }, false)
+  .sortValues("kwh", false);
+console.log("\nCampus intensity summary:");
+console.log(campusSummary.toString());</textarea>
+      <textarea class="playground-python" style="display:none">import pandas as pd
+
+readings = pd.DataFrame([
+    {"hour": "08:00", "building_id": "B01", "meter": "main", "kwh": 72, "outdoor_c": 19, "occupancy": 118},
+    {"hour": "08:00", "building_id": "B02", "meter": "main", "kwh": 54, "outdoor_c": 18, "occupancy": 76},
+    {"hour": "08:00", "building_id": "B03", "meter": "main", "kwh": 91, "outdoor_c": 22, "occupancy": 140},
+    {"hour": "09:00", "building_id": "B01", "meter": "main", "kwh": 78, "outdoor_c": 21, "occupancy": 132},
+    {"hour": "09:00", "building_id": "B02", "meter": "main", "kwh": 58, "outdoor_c": 20, "occupancy": 82},
+    {"hour": "09:00", "building_id": "B03", "meter": "main", "kwh": 116, "outdoor_c": 24, "occupancy": 148},
+    {"hour": "10:00", "building_id": "B01", "meter": "main", "kwh": 84, "outdoor_c": 22, "occupancy": 138},
+    {"hour": "10:00", "building_id": "B02", "meter": "main", "kwh": 61, "outdoor_c": 22, "occupancy": 89},
+    {"hour": "10:00", "building_id": "B03", "meter": "main", "kwh": 143, "outdoor_c": 26, "occupancy": 151},
+])
+buildings = pd.DataFrame([
+    {"building_id": "B01", "campus": "North", "sqft": 42000, "system": "mixed-use"},
+    {"building_id": "B02", "campus": "North", "sqft": 28000, "system": "office"},
+    {"building_id": "B03", "campus": "South", "sqft": 51000, "system": "lab"},
+])
+enriched = readings.merge(buildings, on="building_id", how="left")
+enriched["kwh_per_ksqft"] = enriched["kwh"] / enriched["sqft"] * 1000
+enriched["occupant_kwh"] = enriched["kwh"] / enriched["occupancy"]
+enriched["weather_adjusted_kwh"] = enriched["kwh"] - (enriched["outdoor_c"] - 18) * 1.5
+print(enriched[["hour", "building_id", "campus", "kwh", "kwh_per_ksqft", "occupant_kwh", "weather_adjusted_kwh"]])
+print(enriched.groupby("campus", as_index=False).agg({"kwh": "sum", "kwh_per_ksqft": "mean", "occupant_kwh": "mean"}).sort_values("kwh", ascending=False))</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>2 · Flag spikes against a rolling baseline</h2>
+    <p>Use recent same-building history as a simple expected-consumption baseline.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, nlargestDataFrame, pivotTableFull } from "tsb";
+
+const rows = [
+  { hour: "08:00", building_id: "B01", kwh: 72 },
+  { hour: "08:00", building_id: "B02", kwh: 54 },
+  { hour: "08:00", building_id: "B03", kwh: 91 },
+  { hour: "09:00", building_id: "B01", kwh: 78 },
+  { hour: "09:00", building_id: "B02", kwh: 58 },
+  { hour: "09:00", building_id: "B03", kwh: 116 },
+  { hour: "10:00", building_id: "B01", kwh: 84 },
+  { hour: "10:00", building_id: "B02", kwh: 61 },
+  { hour: "10:00", building_id: "B03", kwh: 143 },
+  { hour: "11:00", building_id: "B01", kwh: 88 },
+  { hour: "11:00", building_id: "B02", kwh: 63 },
+  { hour: "11:00", building_id: "B03", kwh: 181 },
+];
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+const baseline = rows.map((row, index) =&gt; {
+  const history = rows.slice(0, index).filter((item) =&gt; item.building_id === row.building_id).slice(-3);
+  if (history.length === 0) return row.kwh;
+  return history.reduce((sum, item) =&gt; sum + item.kwh, 0) / history.length;
+});
+const anomalyPct = rows.map((row, index) =&gt; {
+  const expected = baseline[index] ?? row.kwh;
+  return round1(((row.kwh - expected) / expected) * 100);
+});
+const severity = anomalyPct.map((pct) =&gt; {
+  if (pct &gt;= 25) return "critical";
+  if (pct &gt;= 15) return "watch";
+  return "normal";
+});
+const alertFlag = severity.map((level) =&gt; level === "normal" ? 0 : 1);
+const flagged = DataFrame.fromRecords(rows).assign({
+  baseline_kwh: baseline.map(round1),
+  anomaly_pct: anomalyPct,
+  severity,
+  alert_flag: alertFlag,
+});
+
+console.log(flagged.toString());
+
+const alerts = flagged.filter(flagged.col("anomaly_pct").ge(15));
+console.log("\nAlert queue:");
+console.log(nlargestDataFrame(alerts, 5, { columns: "anomaly_pct" }).select(["hour", "building_id", "kwh", "baseline_kwh", "anomaly_pct", "severity"]).toString());
+
+const heatmap = pivotTableFull(flagged, {
+  index: "building_id",
+  columns: "severity",
+  values: "alert_flag",
+  aggfunc: "sum",
+  fill_value: 0,
+  margins: true,
+});
+console.log("\nAlert counts by building:");
+console.log(heatmap.toString());</textarea>
+      <textarea class="playground-python" style="display:none">import numpy as np
+import pandas as pd
+
+rows = pd.DataFrame([
+    {"hour": "08:00", "building_id": "B01", "kwh": 72},
+    {"hour": "08:00", "building_id": "B02", "kwh": 54},
+    {"hour": "08:00", "building_id": "B03", "kwh": 91},
+    {"hour": "09:00", "building_id": "B01", "kwh": 78},
+    {"hour": "09:00", "building_id": "B02", "kwh": 58},
+    {"hour": "09:00", "building_id": "B03", "kwh": 116},
+    {"hour": "10:00", "building_id": "B01", "kwh": 84},
+    {"hour": "10:00", "building_id": "B02", "kwh": 61},
+    {"hour": "10:00", "building_id": "B03", "kwh": 143},
+    {"hour": "11:00", "building_id": "B01", "kwh": 88},
+    {"hour": "11:00", "building_id": "B02", "kwh": 63},
+    {"hour": "11:00", "building_id": "B03", "kwh": 181},
+])
+rows["baseline_kwh"] = (
+    rows.groupby("building_id")["kwh"]
+    .transform(lambda s: s.shift(1).rolling(3, min_periods=1).mean())
+    .fillna(rows["kwh"])
+    .round(1)
+)
+rows["anomaly_pct"] = ((rows["kwh"] - rows["baseline_kwh"]) / rows["baseline_kwh"] * 100).round(1)
+rows["severity"] = np.select(
+    [rows["anomaly_pct"] &gt;= 25, rows["anomaly_pct"] &gt;= 15],
+    ["critical", "watch"],
+    default="normal",
+)
+rows["alert_flag"] = np.where(rows["severity"] == "normal", 0, 1)
+print(rows)
+alerts = rows[rows["anomaly_pct"] &gt;= 15]
+print(alerts.nlargest(5, "anomaly_pct")[["hour", "building_id", "kwh", "baseline_kwh", "anomaly_pct", "severity"]])
+print(pd.pivot_table(rows, index="building_id", columns="severity", values="alert_flag", aggfunc="sum", fill_value=0, margins=True))</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>3 · Convert alerts into maintenance economics</h2>
+    <p>Join alert records to tariff and building context, then estimate savings opportunity.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, merge, nlargestDataFrame, pivotTableFull } from "tsb";
+
+const tickets = DataFrame.fromRecords([
+  { ticket_id: "m301", building_id: "B03", system: "chiller", severity: "critical", excess_kwh: 55, status: "open" },
+  { ticket_id: "m302", building_id: "B03", system: "ventilation", severity: "watch", excess_kwh: 27, status: "open" },
+  { ticket_id: "m303", building_id: "B01", system: "lighting", severity: "watch", excess_kwh: 14, status: "scheduled" },
+  { ticket_id: "m304", building_id: "B02", system: "plug load", severity: "watch", excess_kwh: 9, status: "scheduled" },
+  { ticket_id: "m305", building_id: "B03", system: "chiller", severity: "critical", excess_kwh: 38, status: "open" },
+  { ticket_id: "m306", building_id: "B01", system: "air handling", severity: "normal", excess_kwh: 6, status: "monitor" },
+]);
+const buildingContext = DataFrame.fromRecords([
+  { building_id: "B01", campus: "North", rate_per_kwh: 0.18 },
+  { building_id: "B02", campus: "North", rate_per_kwh: 0.18 },
+  { building_id: "B03", campus: "South", rate_per_kwh: 0.24 },
+]);
+
+const enriched = merge(tickets, buildingContext, { on: "building_id", how: "left" }).assign({
+  estimated_cost: (df) =&gt; df.col("excess_kwh").mul(df.col("rate_per_kwh")),
+});
+console.log(enriched.select(["ticket_id", "building_id", "campus", "system", "severity", "excess_kwh", "estimated_cost", "status"]).toString());
+
+const systemSummary = enriched
+  .groupby("system")
+  .agg({ excess_kwh: "sum", estimated_cost: "sum" }, false)
+  .sortValues("estimated_cost", false);
+console.log("\nSavings opportunity by system:");
+console.log(systemSummary.toString());
+
+const costByStatus = pivotTableFull(enriched, {
+  index: "system",
+  columns: "status",
+  values: "estimated_cost",
+  aggfunc: "sum",
+  fill_value: 0,
+  margins: true,
+});
+console.log("\nEstimated cost by system/status:");
+console.log(costByStatus.toString());
+
+console.log("\nTickets to dispatch first:");
+console.log(nlargestDataFrame(enriched, 3, { columns: "estimated_cost" }).select(["ticket_id", "building_id", "system", "estimated_cost", "status"]).toString());</textarea>
+      <textarea class="playground-python" style="display:none">import pandas as pd
+
+tickets = pd.DataFrame([
+    {"ticket_id": "m301", "building_id": "B03", "system": "chiller", "severity": "critical", "excess_kwh": 55, "status": "open"},
+    {"ticket_id": "m302", "building_id": "B03", "system": "ventilation", "severity": "watch", "excess_kwh": 27, "status": "open"},
+    {"ticket_id": "m303", "building_id": "B01", "system": "lighting", "severity": "watch", "excess_kwh": 14, "status": "scheduled"},
+    {"ticket_id": "m304", "building_id": "B02", "system": "plug load", "severity": "watch", "excess_kwh": 9, "status": "scheduled"},
+    {"ticket_id": "m305", "building_id": "B03", "system": "chiller", "severity": "critical", "excess_kwh": 38, "status": "open"},
+    {"ticket_id": "m306", "building_id": "B01", "system": "air handling", "severity": "normal", "excess_kwh": 6, "status": "monitor"},
+])
+building_context = pd.DataFrame([
+    {"building_id": "B01", "campus": "North", "rate_per_kwh": 0.18},
+    {"building_id": "B02", "campus": "North", "rate_per_kwh": 0.18},
+    {"building_id": "B03", "campus": "South", "rate_per_kwh": 0.24},
+])
+enriched = tickets.merge(building_context, on="building_id", how="left")
+enriched["estimated_cost"] = enriched["excess_kwh"] * enriched["rate_per_kwh"]
+print(enriched[["ticket_id", "building_id", "campus", "system", "severity", "excess_kwh", "estimated_cost", "status"]])
+print(enriched.groupby("system", as_index=False).agg({"excess_kwh": "sum", "estimated_cost": "sum"}).sort_values("estimated_cost", ascending=False))
+print(pd.pivot_table(enriched, index="system", columns="status", values="estimated_cost", aggfunc="sum", fill_value=0, margins=True))
+print(enriched.nlargest(3, "estimated_cost")[["ticket_id", "building_id", "system", "estimated_cost", "status"]])</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <footer>
+    <p>
+      <a href="examples.html">All examples</a> ·
+      <a href="index.html">tsb playground</a> ·
+      Built by <a href="https://github.com/githubnext/autoloop">Autoloop</a>
+    </p>
+  </footer>
+  <script type="module" src="playground-runtime.js"></script>
+</body>
+</html>

--- a/playground/example_fulfillment_sla.html
+++ b/playground/example_fulfillment_sla.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>tsb — Fulfillment SLA Control Tower — Examples</title>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --accent: #58a6ff;
+      --green: #3fb950;
+      --orange: #d29922;
+      --red: #f85149;
+      --font-mono: "Cascadia Code", "Fira Code", "JetBrains Mono", monospace;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: system-ui, -apple-system, sans-serif;
+      line-height: 1.6;
+      padding: 2rem;
+      max-width: 920px;
+      margin: 0 auto;
+    }
+    a { color: var(--accent); }
+    h1 { color: var(--accent); margin-bottom: 0.5rem; }
+    h2 { margin-top: 0; margin-bottom: 0.5rem; font-size: 1.25rem; }
+    p  { color: #8b949e; margin-bottom: 1rem; }
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.875em;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.3rem;
+      padding: 0.1rem 0.4rem;
+    }
+    .back { margin-bottom: 1.25rem; display: inline-block; }
+    .scenario {
+      background: rgba(88, 166, 255, 0.06);
+      border-left: 3px solid var(--accent);
+      padding: 0.75rem 1rem;
+      border-radius: 0 0.4rem 0.4rem 0;
+      margin: 1rem 0 1.5rem;
+      color: #c9d1d9;
+    }
+    .scenario strong { color: var(--accent); }
+    #playground-loading {
+      position: fixed; inset: 0;
+      background: rgba(13, 17, 23, 0.92);
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      z-index: 1000; gap: 1rem;
+    }
+    .spinner {
+      width: 40px; height: 40px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    #playground-status { color: #8b949e; font-size: 0.95rem; }
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .section p { margin-bottom: 0.75rem; }
+    .playground-block { margin-top: 0.75rem; }
+    .playground-header {
+      display: flex; align-items: center; justify-content: space-between;
+      background: #1c2128; border: 1px solid var(--border);
+      border-bottom: none; border-radius: 0.5rem 0.5rem 0 0;
+      padding: 0.4rem 0.75rem;
+    }
+    .playground-label {
+      font-size: 0.75rem; color: #8b949e;
+      text-transform: uppercase; letter-spacing: 0.05em;
+    }
+    .playground-actions { display: flex; gap: 0.5rem; }
+    .playground-actions button {
+      background: transparent; color: var(--accent);
+      border: 1px solid var(--border); border-radius: 0.35rem;
+      padding: 0.25rem 0.7rem; font-size: 0.8rem;
+      cursor: pointer; font-family: system-ui, sans-serif;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .playground-actions button:hover:not(:disabled) {
+      background: rgba(88, 166, 255, 0.1);
+      border-color: var(--accent);
+    }
+    .playground-actions button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .playground-run { font-weight: 600; }
+    .playground-editor {
+      display: block; width: 100%; min-height: 80px;
+      background: #0d1117; color: var(--text);
+      border: 1px solid var(--border);
+      border-top: none; border-bottom: none;
+      padding: 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.875rem; line-height: 1.55;
+      resize: vertical; outline: none;
+      tab-size: 2; white-space: pre; overflow-x: auto;
+    }
+    .playground-editor:focus {
+      border-color: var(--accent);
+      box-shadow: inset 0 0 0 1px var(--accent);
+    }
+    .playground-output {
+      background: #1c2333;
+      border: 1px solid var(--border);
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.85rem; color: #8b949e;
+      white-space: pre-wrap; min-height: 2rem;
+      word-break: break-word;
+    }
+    .playground-output.active { color: var(--green); border-color: var(--green); }
+    .playground-output.error { color: var(--red); border-color: var(--red); }
+    .playground-hint {
+      font-size: 0.75rem; color: #484f58;
+      margin-top: 0.35rem; text-align: right;
+    }
+    footer {
+      text-align: center; padding: 2rem 0;
+      color: #8b949e; font-size: 0.85rem;
+      border-top: 1px solid var(--border);
+      margin-top: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div id="playground-loading">
+    <div class="spinner"></div>
+    <div id="playground-status">Initializing playground…</div>
+  </div>
+
+  <a class="back" href="examples.html">← Back to examples</a>
+  <h1>🚚 Fulfillment SLA Control Tower</h1>
+  <div class="scenario"><strong>Scenario:</strong> An e-commerce operations team has order, shipment, carrier, and warehouse-capacity data. They need a daily control tower for late orders, carrier misses, and aging backlog.</div>
+  <p>Skills you'll use: chained <code>merge</code>, SLA variance metrics, boolean filters, <code>nlargestDataFrame</code>, <code>groupby().agg()</code>, backlog bucketing, and pivot-table heatmaps.</p>
+
+  <div class="section">
+    <h2>1 · Join order, shipment, and carrier facts</h2>
+    <p>Calculate days late, carrier variance, and an exception score for customer-impact triage.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, merge, nlargestDataFrame } from "tsb";
+
+const orders = DataFrame.fromRecords([
+  { order_id: "o1001", customer_tier: "gold", warehouse: "WH-East", order_value: 840, promised_days: 2 },
+  { order_id: "o1002", customer_tier: "standard", warehouse: "WH-West", order_value: 215, promised_days: 4 },
+  { order_id: "o1003", customer_tier: "gold", warehouse: "WH-East", order_value: 1240, promised_days: 2 },
+  { order_id: "o1004", customer_tier: "standard", warehouse: "WH-South", order_value: 180, promised_days: 5 },
+  { order_id: "o1005", customer_tier: "silver", warehouse: "WH-West", order_value: 520, promised_days: 3 },
+  { order_id: "o1006", customer_tier: "gold", warehouse: "WH-South", order_value: 760, promised_days: 2 },
+  { order_id: "o1007", customer_tier: "standard", warehouse: "WH-East", order_value: 130, promised_days: 4 },
+  { order_id: "o1008", customer_tier: "silver", warehouse: "WH-West", order_value: 680, promised_days: 3 },
+]);
+const shipments = DataFrame.fromRecords([
+  { order_id: "o1001", carrier: "ParcelPro", ship_days: 3, scan_exceptions: 1 },
+  { order_id: "o1002", carrier: "BudgetFreight", ship_days: 4, scan_exceptions: 0 },
+  { order_id: "o1003", carrier: "SwiftShip", ship_days: 2, scan_exceptions: 0 },
+  { order_id: "o1004", carrier: "BudgetFreight", ship_days: 7, scan_exceptions: 2 },
+  { order_id: "o1005", carrier: "ParcelPro", ship_days: 5, scan_exceptions: 1 },
+  { order_id: "o1006", carrier: "SwiftShip", ship_days: 4, scan_exceptions: 1 },
+  { order_id: "o1007", carrier: "ParcelPro", ship_days: 3, scan_exceptions: 0 },
+  { order_id: "o1008", carrier: "BudgetFreight", ship_days: 6, scan_exceptions: 2 },
+]);
+const carriers = DataFrame.fromRecords([
+  { carrier: "ParcelPro", sla_days: 3, cost_per_pkg: 11.5 },
+  { carrier: "SwiftShip", sla_days: 2, cost_per_pkg: 14.75 },
+  { carrier: "BudgetFreight", sla_days: 5, cost_per_pkg: 8.25 },
+]);
+
+const joined = merge(
+  merge(orders, shipments, { on: "order_id", how: "left" }),
+  carriers,
+  { on: "carrier", how: "left" },
+).assign({
+  days_late: (df) =&gt; df.col("ship_days").sub(df.col("promised_days")),
+  carrier_variance: (df) =&gt; df.col("ship_days").sub(df.col("sla_days")),
+  exception_score: (df) =&gt; df.col("ship_days").sub(df.col("sla_days")).add(df.col("scan_exceptions").mul(2)),
+});
+
+console.log(joined.select(["order_id", "warehouse", "carrier", "customer_tier", "order_value", "days_late", "exception_score"]).toString());
+
+const late = joined.filter(joined.col("days_late").gt(0));
+console.log("\nHigh-value late orders:");
+console.log(nlargestDataFrame(late, 4, { columns: "order_value" }).select(["order_id", "warehouse", "carrier", "order_value", "days_late"]).toString());</textarea>
+      <textarea class="playground-python" style="display:none">import pandas as pd
+
+orders = pd.DataFrame([
+    {"order_id": "o1001", "customer_tier": "gold", "warehouse": "WH-East", "order_value": 840, "promised_days": 2},
+    {"order_id": "o1002", "customer_tier": "standard", "warehouse": "WH-West", "order_value": 215, "promised_days": 4},
+    {"order_id": "o1003", "customer_tier": "gold", "warehouse": "WH-East", "order_value": 1240, "promised_days": 2},
+    {"order_id": "o1004", "customer_tier": "standard", "warehouse": "WH-South", "order_value": 180, "promised_days": 5},
+    {"order_id": "o1005", "customer_tier": "silver", "warehouse": "WH-West", "order_value": 520, "promised_days": 3},
+    {"order_id": "o1006", "customer_tier": "gold", "warehouse": "WH-South", "order_value": 760, "promised_days": 2},
+    {"order_id": "o1007", "customer_tier": "standard", "warehouse": "WH-East", "order_value": 130, "promised_days": 4},
+    {"order_id": "o1008", "customer_tier": "silver", "warehouse": "WH-West", "order_value": 680, "promised_days": 3},
+])
+shipments = pd.DataFrame([
+    {"order_id": "o1001", "carrier": "ParcelPro", "ship_days": 3, "scan_exceptions": 1},
+    {"order_id": "o1002", "carrier": "BudgetFreight", "ship_days": 4, "scan_exceptions": 0},
+    {"order_id": "o1003", "carrier": "SwiftShip", "ship_days": 2, "scan_exceptions": 0},
+    {"order_id": "o1004", "carrier": "BudgetFreight", "ship_days": 7, "scan_exceptions": 2},
+    {"order_id": "o1005", "carrier": "ParcelPro", "ship_days": 5, "scan_exceptions": 1},
+    {"order_id": "o1006", "carrier": "SwiftShip", "ship_days": 4, "scan_exceptions": 1},
+    {"order_id": "o1007", "carrier": "ParcelPro", "ship_days": 3, "scan_exceptions": 0},
+    {"order_id": "o1008", "carrier": "BudgetFreight", "ship_days": 6, "scan_exceptions": 2},
+])
+carriers = pd.DataFrame([
+    {"carrier": "ParcelPro", "sla_days": 3, "cost_per_pkg": 11.5},
+    {"carrier": "SwiftShip", "sla_days": 2, "cost_per_pkg": 14.75},
+    {"carrier": "BudgetFreight", "sla_days": 5, "cost_per_pkg": 8.25},
+])
+joined = orders.merge(shipments, on="order_id", how="left").merge(carriers, on="carrier", how="left")
+joined["days_late"] = joined["ship_days"] - joined["promised_days"]
+joined["carrier_variance"] = joined["ship_days"] - joined["sla_days"]
+joined["exception_score"] = joined["carrier_variance"] + joined["scan_exceptions"] * 2
+print(joined[["order_id", "warehouse", "carrier", "customer_tier", "order_value", "days_late", "exception_score"]])
+print(joined[joined["days_late"] &gt; 0].nlargest(4, "order_value")[["order_id", "warehouse", "carrier", "order_value", "days_late"]])</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>2 · Score carrier and warehouse SLA misses</h2>
+    <p>Summarize late volume by carrier and build a warehouse × carrier heatmap.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, nlargestDataFrame, pivotTableFull } from "tsb";
+
+const scored = DataFrame.fromRecords([
+  { order_id: "o1001", warehouse: "WH-East", carrier: "ParcelPro", late_flag: 1, days_late: 1, order_value: 840 },
+  { order_id: "o1002", warehouse: "WH-West", carrier: "BudgetFreight", late_flag: 0, days_late: 0, order_value: 215 },
+  { order_id: "o1003", warehouse: "WH-East", carrier: "SwiftShip", late_flag: 0, days_late: 0, order_value: 1240 },
+  { order_id: "o1004", warehouse: "WH-South", carrier: "BudgetFreight", late_flag: 1, days_late: 2, order_value: 180 },
+  { order_id: "o1005", warehouse: "WH-West", carrier: "ParcelPro", late_flag: 1, days_late: 2, order_value: 520 },
+  { order_id: "o1006", warehouse: "WH-South", carrier: "SwiftShip", late_flag: 1, days_late: 2, order_value: 760 },
+  { order_id: "o1007", warehouse: "WH-East", carrier: "ParcelPro", late_flag: 0, days_late: -1, order_value: 130 },
+  { order_id: "o1008", warehouse: "WH-West", carrier: "BudgetFreight", late_flag: 1, days_late: 3, order_value: 680 },
+]);
+
+const carrierSummary = scored
+  .groupby("carrier")
+  .agg({ late_flag: "sum", days_late: "mean", order_value: "sum" }, false)
+  .sortValues("late_flag", false);
+console.log("Carrier SLA summary:");
+console.log(carrierSummary.toString());
+
+const lateHeatmap = pivotTableFull(scored, {
+  index: "warehouse",
+  columns: "carrier",
+  values: "late_flag",
+  aggfunc: "sum",
+  fill_value: 0,
+  margins: true,
+});
+console.log("\nLate shipments by warehouse/carrier:");
+console.log(lateHeatmap.toString());
+
+const lateOrders = scored.filter(scored.col("late_flag").eq(1));
+console.log("\nLargest late orders:");
+console.log(nlargestDataFrame(lateOrders, 3, { columns: "order_value" }).select(["order_id", "warehouse", "carrier", "order_value", "days_late"]).toString());</textarea>
+      <textarea class="playground-python" style="display:none">import pandas as pd
+
+scored = pd.DataFrame([
+    {"order_id": "o1001", "warehouse": "WH-East", "carrier": "ParcelPro", "late_flag": 1, "days_late": 1, "order_value": 840},
+    {"order_id": "o1002", "warehouse": "WH-West", "carrier": "BudgetFreight", "late_flag": 0, "days_late": 0, "order_value": 215},
+    {"order_id": "o1003", "warehouse": "WH-East", "carrier": "SwiftShip", "late_flag": 0, "days_late": 0, "order_value": 1240},
+    {"order_id": "o1004", "warehouse": "WH-South", "carrier": "BudgetFreight", "late_flag": 1, "days_late": 2, "order_value": 180},
+    {"order_id": "o1005", "warehouse": "WH-West", "carrier": "ParcelPro", "late_flag": 1, "days_late": 2, "order_value": 520},
+    {"order_id": "o1006", "warehouse": "WH-South", "carrier": "SwiftShip", "late_flag": 1, "days_late": 2, "order_value": 760},
+    {"order_id": "o1007", "warehouse": "WH-East", "carrier": "ParcelPro", "late_flag": 0, "days_late": -1, "order_value": 130},
+    {"order_id": "o1008", "warehouse": "WH-West", "carrier": "BudgetFreight", "late_flag": 1, "days_late": 3, "order_value": 680},
+])
+print(scored.groupby("carrier", as_index=False).agg({"late_flag": "sum", "days_late": "mean", "order_value": "sum"}).sort_values("late_flag", ascending=False))
+print(pd.pivot_table(scored, index="warehouse", columns="carrier", values="late_flag", aggfunc="sum", fill_value=0, margins=True))
+print(scored[scored["late_flag"] == 1].nlargest(3, "order_value")[["order_id", "warehouse", "carrier", "order_value", "days_late"]])</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>3 · Age the open backlog against staffing capacity</h2>
+    <p>Bucket open work by age, merge staffing capacity, and identify overloaded warehouses.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, merge, pivotTableFull } from "tsb";
+
+const backlogRows = [
+  { order_id: "b201", warehouse: "WH-East", status: "pick", age_hours: 5, pick_units: 12, pack_units: 0 },
+  { order_id: "b202", warehouse: "WH-East", status: "pack", age_hours: 14, pick_units: 0, pack_units: 9 },
+  { order_id: "b203", warehouse: "WH-West", status: "pick", age_hours: 27, pick_units: 18, pack_units: 0 },
+  { order_id: "b204", warehouse: "WH-West", status: "pack", age_hours: 36, pick_units: 0, pack_units: 16 },
+  { order_id: "b205", warehouse: "WH-South", status: "pick", age_hours: 9, pick_units: 10, pack_units: 0 },
+  { order_id: "b206", warehouse: "WH-South", status: "pack", age_hours: 52, pick_units: 0, pack_units: 22 },
+  { order_id: "b207", warehouse: "WH-East", status: "pick", age_hours: 31, pick_units: 14, pack_units: 0 },
+  { order_id: "b208", warehouse: "WH-West", status: "pick", age_hours: 6, pick_units: 8, pack_units: 0 },
+];
+const ageBucket = backlogRows.map((row) =&gt; {
+  if (row.age_hours &gt;= 48) return "48h+";
+  if (row.age_hours &gt;= 24) return "24-48h";
+  if (row.age_hours &gt;= 8) return "8-24h";
+  return "&lt;8h";
+});
+const backlog = DataFrame.fromRecords(backlogRows).assign({ age_bucket: ageBucket });
+const capacity = DataFrame.fromRecords([
+  { warehouse: "WH-East", pickers: 5, packers: 4 },
+  { warehouse: "WH-West", pickers: 3, packers: 3 },
+  { warehouse: "WH-South", pickers: 2, packers: 2 },
+]);
+
+const workload = backlog
+  .groupby("warehouse")
+  .agg({ pick_units: "sum", pack_units: "sum", age_hours: "mean" }, false);
+const staffingPlan = merge(workload, capacity, { on: "warehouse", how: "left" }).assign({
+  pick_units_per_picker: (df) =&gt; df.col("pick_units").div(df.col("pickers")),
+  pack_units_per_packer: (df) =&gt; df.col("pack_units").div(df.col("packers")),
+});
+console.log("Staffing pressure:");
+console.log(staffingPlan.sortValues("pick_units_per_picker", false).toString());
+
+const agingHeatmap = pivotTableFull(backlog, {
+  index: "warehouse",
+  columns: "age_bucket",
+  values: "pick_units",
+  aggfunc: "sum",
+  fill_value: 0,
+  margins: true,
+});
+console.log("\nOpen pick units by age bucket:");
+console.log(agingHeatmap.toString());</textarea>
+      <textarea class="playground-python" style="display:none">import numpy as np
+import pandas as pd
+
+backlog_rows = [
+    {"order_id": "b201", "warehouse": "WH-East", "status": "pick", "age_hours": 5, "pick_units": 12, "pack_units": 0},
+    {"order_id": "b202", "warehouse": "WH-East", "status": "pack", "age_hours": 14, "pick_units": 0, "pack_units": 9},
+    {"order_id": "b203", "warehouse": "WH-West", "status": "pick", "age_hours": 27, "pick_units": 18, "pack_units": 0},
+    {"order_id": "b204", "warehouse": "WH-West", "status": "pack", "age_hours": 36, "pick_units": 0, "pack_units": 16},
+    {"order_id": "b205", "warehouse": "WH-South", "status": "pick", "age_hours": 9, "pick_units": 10, "pack_units": 0},
+    {"order_id": "b206", "warehouse": "WH-South", "status": "pack", "age_hours": 52, "pick_units": 0, "pack_units": 22},
+    {"order_id": "b207", "warehouse": "WH-East", "status": "pick", "age_hours": 31, "pick_units": 14, "pack_units": 0},
+    {"order_id": "b208", "warehouse": "WH-West", "status": "pick", "age_hours": 6, "pick_units": 8, "pack_units": 0},
+]
+backlog = pd.DataFrame(backlog_rows)
+backlog["age_bucket"] = np.select(
+    [backlog["age_hours"] &gt;= 48, backlog["age_hours"] &gt;= 24, backlog["age_hours"] &gt;= 8],
+    ["48h+", "24-48h", "8-24h"],
+    default="&lt;8h",
+)
+capacity = pd.DataFrame([
+    {"warehouse": "WH-East", "pickers": 5, "packers": 4},
+    {"warehouse": "WH-West", "pickers": 3, "packers": 3},
+    {"warehouse": "WH-South", "pickers": 2, "packers": 2},
+])
+workload = backlog.groupby("warehouse", as_index=False).agg({"pick_units": "sum", "pack_units": "sum", "age_hours": "mean"})
+staffing_plan = workload.merge(capacity, on="warehouse", how="left")
+staffing_plan["pick_units_per_picker"] = staffing_plan["pick_units"] / staffing_plan["pickers"]
+staffing_plan["pack_units_per_packer"] = staffing_plan["pack_units"] / staffing_plan["packers"]
+print(staffing_plan.sort_values("pick_units_per_picker", ascending=False))
+print(pd.pivot_table(backlog, index="warehouse", columns="age_bucket", values="pick_units", aggfunc="sum", fill_value=0, margins=True))</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <footer>
+    <p>
+      <a href="examples.html">All examples</a> ·
+      <a href="index.html">tsb playground</a> ·
+      Built by <a href="https://github.com/githubnext/autoloop">Autoloop</a>
+    </p>
+  </footer>
+  <script type="module" src="playground-runtime.js"></script>
+</body>
+</html>

--- a/playground/example_subscription_revenue_waterfall.html
+++ b/playground/example_subscription_revenue_waterfall.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>tsb — Subscription Revenue Waterfall — Examples</title>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --accent: #58a6ff;
+      --green: #3fb950;
+      --orange: #d29922;
+      --red: #f85149;
+      --font-mono: "Cascadia Code", "Fira Code", "JetBrains Mono", monospace;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: system-ui, -apple-system, sans-serif;
+      line-height: 1.6;
+      padding: 2rem;
+      max-width: 920px;
+      margin: 0 auto;
+    }
+    a { color: var(--accent); }
+    h1 { color: var(--accent); margin-bottom: 0.5rem; }
+    h2 { margin-top: 0; margin-bottom: 0.5rem; font-size: 1.25rem; }
+    p  { color: #8b949e; margin-bottom: 1rem; }
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.875em;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.3rem;
+      padding: 0.1rem 0.4rem;
+    }
+    .back { margin-bottom: 1.25rem; display: inline-block; }
+    .scenario {
+      background: rgba(88, 166, 255, 0.06);
+      border-left: 3px solid var(--accent);
+      padding: 0.75rem 1rem;
+      border-radius: 0 0.4rem 0.4rem 0;
+      margin: 1rem 0 1.5rem;
+      color: #c9d1d9;
+    }
+    .scenario strong { color: var(--accent); }
+    #playground-loading {
+      position: fixed; inset: 0;
+      background: rgba(13, 17, 23, 0.92);
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      z-index: 1000; gap: 1rem;
+    }
+    .spinner {
+      width: 40px; height: 40px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    #playground-status { color: #8b949e; font-size: 0.95rem; }
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 0.75rem;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .section p { margin-bottom: 0.75rem; }
+    .playground-block { margin-top: 0.75rem; }
+    .playground-header {
+      display: flex; align-items: center; justify-content: space-between;
+      background: #1c2128; border: 1px solid var(--border);
+      border-bottom: none; border-radius: 0.5rem 0.5rem 0 0;
+      padding: 0.4rem 0.75rem;
+    }
+    .playground-label {
+      font-size: 0.75rem; color: #8b949e;
+      text-transform: uppercase; letter-spacing: 0.05em;
+    }
+    .playground-actions { display: flex; gap: 0.5rem; }
+    .playground-actions button {
+      background: transparent; color: var(--accent);
+      border: 1px solid var(--border); border-radius: 0.35rem;
+      padding: 0.25rem 0.7rem; font-size: 0.8rem;
+      cursor: pointer; font-family: system-ui, sans-serif;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .playground-actions button:hover:not(:disabled) {
+      background: rgba(88, 166, 255, 0.1);
+      border-color: var(--accent);
+    }
+    .playground-actions button:disabled { opacity: 0.4; cursor: not-allowed; }
+    .playground-run { font-weight: 600; }
+    .playground-editor {
+      display: block; width: 100%; min-height: 80px;
+      background: #0d1117; color: var(--text);
+      border: 1px solid var(--border);
+      border-top: none; border-bottom: none;
+      padding: 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.875rem; line-height: 1.55;
+      resize: vertical; outline: none;
+      tab-size: 2; white-space: pre; overflow-x: auto;
+    }
+    .playground-editor:focus {
+      border-color: var(--accent);
+      box-shadow: inset 0 0 0 1px var(--accent);
+    }
+    .playground-output {
+      background: #1c2333;
+      border: 1px solid var(--border);
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.85rem; color: #8b949e;
+      white-space: pre-wrap; min-height: 2rem;
+      word-break: break-word;
+    }
+    .playground-output.active { color: var(--green); border-color: var(--green); }
+    .playground-output.error { color: var(--red); border-color: var(--red); }
+    .playground-hint {
+      font-size: 0.75rem; color: #484f58;
+      margin-top: 0.35rem; text-align: right;
+    }
+    footer {
+      text-align: center; padding: 2rem 0;
+      color: #8b949e; font-size: 0.85rem;
+      border-top: 1px solid var(--border);
+      margin-top: 2rem;
+    }
+  </style>
+</head>
+<body>
+  <div id="playground-loading">
+    <div class="spinner"></div>
+    <div id="playground-status">Initializing playground…</div>
+  </div>
+
+  <a class="back" href="examples.html">← Back to examples</a>
+  <h1>💳 Subscription Revenue Waterfall</h1>
+  <div class="scenario"><strong>Scenario:</strong> A SaaS finance team needs to reconcile monthly invoices, account metadata, expansion, contraction, churn, and cohort retention into one board-ready revenue view.</div>
+  <p>Skills you'll use: <code>merge</code>, derived KPI columns, account snapshots, <code>groupby().agg()</code>, cohort calculations, <code>pivotTableFull</code>, and ranked retention tables.</p>
+
+  <div class="section">
+    <h2>1 · Join invoices to account metadata</h2>
+    <p>Combine billing facts with customer segmentation, then summarize current-month MRR by segment.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, merge } from "tsb";
+
+const accounts = DataFrame.fromRecords([
+  { acct_id: "a01", customer: "Northwind Analytics", segment: "enterprise", region: "NA", signup_month: "2023-11" },
+  { acct_id: "a02", customer: "Brightline Labs", segment: "startup", region: "EU", signup_month: "2023-12" },
+  { acct_id: "a03", customer: "Urban Cart", segment: "midmarket", region: "NA", signup_month: "2024-01" },
+  { acct_id: "a04", customer: "Helio Health", segment: "enterprise", region: "EU", signup_month: "2024-01" },
+  { acct_id: "a05", customer: "Beacon Studio", segment: "startup", region: "NA", signup_month: "2024-02" },
+]);
+const invoices = DataFrame.fromRecords([
+  { month: "2024-03", acct_id: "a01", plan: "scale", seats: 120, mrr: 1440, status: "active" },
+  { month: "2024-03", acct_id: "a02", plan: "team", seats: 0, mrr: 0, status: "churned" },
+  { month: "2024-03", acct_id: "a03", plan: "growth", seats: 42, mrr: 756, status: "active" },
+  { month: "2024-03", acct_id: "a04", plan: "scale", seats: 95, mrr: 1330, status: "active" },
+  { month: "2024-03", acct_id: "a05", plan: "team", seats: 18, mrr: 270, status: "active" },
+]);
+
+const current = merge(invoices, accounts, { on: "acct_id", how: "left" }).assign({
+  arr: (df) =&gt; df.col("mrr").mul(12),
+  mrr_per_seat: (df) =&gt; df.col("mrr").div(df.col("seats")),
+});
+
+console.log("Current customer ledger:");
+console.log(current.select(["acct_id", "customer", "segment", "region", "status", "mrr", "arr", "mrr_per_seat"]).toString());
+
+const segmentSummary = current
+  .groupby("segment")
+  .agg({ mrr: "sum", arr: "sum", seats: "sum" }, false)
+  .sortValues("mrr", false);
+console.log("\nMRR by segment:");
+console.log(segmentSummary.toString());</textarea>
+      <textarea class="playground-python" style="display:none">import pandas as pd
+
+accounts = pd.DataFrame([
+    {"acct_id": "a01", "customer": "Northwind Analytics", "segment": "enterprise", "region": "NA", "signup_month": "2023-11"},
+    {"acct_id": "a02", "customer": "Brightline Labs", "segment": "startup", "region": "EU", "signup_month": "2023-12"},
+    {"acct_id": "a03", "customer": "Urban Cart", "segment": "midmarket", "region": "NA", "signup_month": "2024-01"},
+    {"acct_id": "a04", "customer": "Helio Health", "segment": "enterprise", "region": "EU", "signup_month": "2024-01"},
+    {"acct_id": "a05", "customer": "Beacon Studio", "segment": "startup", "region": "NA", "signup_month": "2024-02"},
+])
+invoices = pd.DataFrame([
+    {"month": "2024-03", "acct_id": "a01", "plan": "scale", "seats": 120, "mrr": 1440, "status": "active"},
+    {"month": "2024-03", "acct_id": "a02", "plan": "team", "seats": 0, "mrr": 0, "status": "churned"},
+    {"month": "2024-03", "acct_id": "a03", "plan": "growth", "seats": 42, "mrr": 756, "status": "active"},
+    {"month": "2024-03", "acct_id": "a04", "plan": "scale", "seats": 95, "mrr": 1330, "status": "active"},
+    {"month": "2024-03", "acct_id": "a05", "plan": "team", "seats": 18, "mrr": 270, "status": "active"},
+])
+current = invoices.merge(accounts, on="acct_id", how="left")
+current["arr"] = current["mrr"] * 12
+current["mrr_per_seat"] = current["mrr"] / current["seats"]
+print(current[["acct_id", "customer", "segment", "region", "status", "mrr", "arr", "mrr_per_seat"]])
+print(current.groupby("segment", as_index=False).agg({"mrr": "sum", "arr": "sum", "seats": "sum"}).sort_values("mrr", ascending=False))</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>2 · Build the monthly MRR movement waterfall</h2>
+    <p>Compare each account to its previous snapshot and classify revenue movement.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, pivotTableFull } from "tsb";
+
+const snapshots = [
+  { month: "2024-01", acct_id: "a01", mrr: 1200 },
+  { month: "2024-01", acct_id: "a02", mrr: 450 },
+  { month: "2024-01", acct_id: "a03", mrr: 560 },
+  { month: "2024-01", acct_id: "a04", mrr: 1100 },
+  { month: "2024-02", acct_id: "a01", mrr: 1440 },
+  { month: "2024-02", acct_id: "a02", mrr: 450 },
+  { month: "2024-02", acct_id: "a03", mrr: 700 },
+  { month: "2024-02", acct_id: "a04", mrr: 1045 },
+  { month: "2024-02", acct_id: "a05", mrr: 240 },
+  { month: "2024-03", acct_id: "a01", mrr: 1440 },
+  { month: "2024-03", acct_id: "a02", mrr: 0 },
+  { month: "2024-03", acct_id: "a03", mrr: 756 },
+  { month: "2024-03", acct_id: "a04", mrr: 1330 },
+  { month: "2024-03", acct_id: "a05", mrr: 270 },
+];
+
+const previous = new Map&lt;string, number&gt;();
+const rows = snapshots.map((row) =&gt; {
+  const prior = previous.get(row.acct_id) ?? 0;
+  previous.set(row.acct_id, row.mrr);
+  const delta = row.mrr - prior;
+  let movement = "retained";
+  if (prior === 0 &amp;&amp; row.mrr &gt; 0) movement = "new";
+  else if (prior &gt; 0 &amp;&amp; row.mrr === 0) movement = "churn";
+  else if (delta &gt; 0) movement = "expansion";
+  else if (delta &lt; 0) movement = "contraction";
+  return { ...row, prior_mrr: prior, delta_mrr: delta, movement };
+});
+
+const movements = DataFrame.fromRecords(rows);
+console.log(movements.select(["month", "acct_id", "prior_mrr", "mrr", "delta_mrr", "movement"]).toString());
+
+const waterfall = movements
+  .groupby("movement")
+  .agg({ delta_mrr: "sum", mrr: "sum" }, false)
+  .sortValues("delta_mrr", false);
+console.log("\nMovement totals:");
+console.log(waterfall.toString());
+
+const byMonth = pivotTableFull(movements, {
+  index: "month",
+  columns: "movement",
+  values: "delta_mrr",
+  aggfunc: "sum",
+  fill_value: 0,
+  margins: true,
+});
+console.log("\nMonthly MRR waterfall:");
+console.log(byMonth.toString());</textarea>
+      <textarea class="playground-python" style="display:none">import numpy as np
+import pandas as pd
+
+snapshots = pd.DataFrame([
+    {"month": "2024-01", "acct_id": "a01", "mrr": 1200},
+    {"month": "2024-01", "acct_id": "a02", "mrr": 450},
+    {"month": "2024-01", "acct_id": "a03", "mrr": 560},
+    {"month": "2024-01", "acct_id": "a04", "mrr": 1100},
+    {"month": "2024-02", "acct_id": "a01", "mrr": 1440},
+    {"month": "2024-02", "acct_id": "a02", "mrr": 450},
+    {"month": "2024-02", "acct_id": "a03", "mrr": 700},
+    {"month": "2024-02", "acct_id": "a04", "mrr": 1045},
+    {"month": "2024-02", "acct_id": "a05", "mrr": 240},
+    {"month": "2024-03", "acct_id": "a01", "mrr": 1440},
+    {"month": "2024-03", "acct_id": "a02", "mrr": 0},
+    {"month": "2024-03", "acct_id": "a03", "mrr": 756},
+    {"month": "2024-03", "acct_id": "a04", "mrr": 1330},
+    {"month": "2024-03", "acct_id": "a05", "mrr": 270},
+]).sort_values(["acct_id", "month"])
+snapshots["prior_mrr"] = snapshots.groupby("acct_id")["mrr"].shift(fill_value=0)
+snapshots["delta_mrr"] = snapshots["mrr"] - snapshots["prior_mrr"]
+snapshots["movement"] = np.select(
+    [
+        (snapshots["prior_mrr"] == 0) &amp; (snapshots["mrr"] &gt; 0),
+        (snapshots["prior_mrr"] &gt; 0) &amp; (snapshots["mrr"] == 0),
+        snapshots["delta_mrr"] &gt; 0,
+        snapshots["delta_mrr"] &lt; 0,
+    ],
+    ["new", "churn", "expansion", "contraction"],
+    default="retained",
+)
+print(snapshots[["month", "acct_id", "prior_mrr", "mrr", "delta_mrr", "movement"]])
+print(snapshots.groupby("movement", as_index=False).agg({"delta_mrr": "sum", "mrr": "sum"}))
+print(pd.pivot_table(snapshots, index="month", columns="movement", values="delta_mrr", aggfunc="sum", fill_value=0, margins=True))</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>3 · Turn monthly activity into a retention matrix</h2>
+    <p>Measure how much of each signup cohort remains active as it ages.</p>
+    <div class="playground-block">
+      <div class="playground-header">
+        <span class="playground-label">TypeScript</span>
+        <div class="playground-actions">
+          <button class="playground-run" disabled>▶ Run</button>
+          <button class="playground-reset">↺ Reset</button>
+        </div>
+      </div>
+      <textarea class="playground-editor" spellcheck="false">import { DataFrame, pivotTableFull } from "tsb";
+
+const activityRows = [
+  { signup_month: "2024-01", active_month: "2024-01", active_accounts: 22 },
+  { signup_month: "2024-01", active_month: "2024-02", active_accounts: 20 },
+  { signup_month: "2024-01", active_month: "2024-03", active_accounts: 17 },
+  { signup_month: "2024-02", active_month: "2024-02", active_accounts: 18 },
+  { signup_month: "2024-02", active_month: "2024-03", active_accounts: 15 },
+  { signup_month: "2024-02", active_month: "2024-04", active_accounts: 13 },
+  { signup_month: "2024-03", active_month: "2024-03", active_accounts: 25 },
+  { signup_month: "2024-03", active_month: "2024-04", active_accounts: 21 },
+  { signup_month: "2024-03", active_month: "2024-05", active_accounts: 19 },
+];
+function monthNumber(value: string): number {
+  return Number(value.slice(0, 4)) * 12 + Number(value.slice(5, 7));
+}
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+const cohortSizes = new Map&lt;string, number&gt;();
+for (const row of activityRows) {
+  if (row.signup_month === row.active_month) {
+    cohortSizes.set(row.signup_month, row.active_accounts);
+  }
+}
+const retentionRows = activityRows.map((row) =&gt; {
+  const cohortSize = cohortSizes.get(row.signup_month) ?? row.active_accounts;
+  const age = monthNumber(row.active_month) - monthNumber(row.signup_month);
+  return {
+    ...row,
+    cohort_age: `M${age}`,
+    cohort_size: cohortSize,
+    retention_pct: round1((row.active_accounts / cohortSize) * 100),
+  };
+});
+
+const retention = DataFrame.fromRecords(retentionRows);
+const matrix = pivotTableFull(retention, {
+  index: "signup_month",
+  columns: "cohort_age",
+  values: "retention_pct",
+  aggfunc: "mean",
+  fill_value: 0,
+});
+console.log("Retention matrix (% active):");
+console.log(matrix.toString());
+
+const m2 = retention
+  .filter(retention.col("cohort_age").eq("M2"))
+  .sortValues("retention_pct", true);
+console.log("\nMonth-2 retention watchlist:");
+console.log(m2.select(["signup_month", "active_accounts", "cohort_size", "retention_pct"]).toString());</textarea>
+      <textarea class="playground-python" style="display:none">import pandas as pd
+
+activity = pd.DataFrame([
+    {"signup_month": "2024-01", "active_month": "2024-01", "active_accounts": 22},
+    {"signup_month": "2024-01", "active_month": "2024-02", "active_accounts": 20},
+    {"signup_month": "2024-01", "active_month": "2024-03", "active_accounts": 17},
+    {"signup_month": "2024-02", "active_month": "2024-02", "active_accounts": 18},
+    {"signup_month": "2024-02", "active_month": "2024-03", "active_accounts": 15},
+    {"signup_month": "2024-02", "active_month": "2024-04", "active_accounts": 13},
+    {"signup_month": "2024-03", "active_month": "2024-03", "active_accounts": 25},
+    {"signup_month": "2024-03", "active_month": "2024-04", "active_accounts": 21},
+    {"signup_month": "2024-03", "active_month": "2024-05", "active_accounts": 19},
+])
+def month_number(value: str) -&gt; int:
+    return int(value[:4]) * 12 + int(value[5:7])
+activity["cohort_size"] = activity.groupby("signup_month")["active_accounts"].transform("max")
+activity["cohort_age"] = activity.apply(lambda r: f"M{month_number(r['active_month']) - month_number(r['signup_month'])}", axis=1)
+activity["retention_pct"] = (activity["active_accounts"] / activity["cohort_size"] * 100).round(1)
+print(pd.pivot_table(activity, index="signup_month", columns="cohort_age", values="retention_pct", aggfunc="mean", fill_value=0))
+print(activity[activity["cohort_age"] == "M2"].sort_values("retention_pct")[["signup_month", "active_accounts", "cohort_size", "retention_pct"]])</textarea>
+      <div class="playground-output">Click ▶ Run to execute</div>
+      <div class="playground-hint">Ctrl+Enter to run · Tab to indent</div>
+    </div>
+  </div>
+
+  <footer>
+    <p>
+      <a href="examples.html">All examples</a> ·
+      <a href="index.html">tsb playground</a> ·
+      Built by <a href="https://github.com/githubnext/autoloop">Autoloop</a>
+    </p>
+  </footer>
+  <script type="module" src="playground-runtime.js"></script>
+</body>
+</html>

--- a/playground/examples.html
+++ b/playground/examples.html
@@ -247,6 +247,24 @@
           <h3>Marketing Attribution ROAS</h3>
           <p>Scenario: A growth team reshapes campaign spend, joins conversion facts, and compares return on ad spend by region and channel.</p>
         </a>
+
+        <a class="example-card" href="example_subscription_revenue_waterfall.html">
+          <div class="example-emoji">💳</div>
+          <h3>Subscription Revenue Waterfall</h3>
+          <p>Scenario: A SaaS finance team reconciles account snapshots, MRR movements, churn, expansion, and cohort retention into a board-ready revenue view.</p>
+        </a>
+
+        <a class="example-card" href="example_fulfillment_sla.html">
+          <div class="example-emoji">🚚</div>
+          <h3>Fulfillment SLA Control Tower</h3>
+          <p>Scenario: An e-commerce operations team joins orders, shipments, carriers, and staffing to triage late packages and aging warehouse backlog.</p>
+        </a>
+
+        <a class="example-card" href="example_energy_anomaly_monitoring.html">
+          <div class="example-emoji">⚡</div>
+          <h3>Energy Anomaly Monitoring</h3>
+          <p>Scenario: A facilities analytics team normalizes smart-meter telemetry, flags consumption spikes, and ranks maintenance tickets by estimated cost impact.</p>
+        </a>
   </div>
 
   <footer>

--- a/playground/index.html
+++ b/playground/index.html
@@ -131,7 +131,7 @@
       <div class="features-grid">
         <div class="feature-card">
           <h3><a href="examples.html" style="color: var(--accent); text-decoration: none;">📚 End-to-end pandas-style scenarios</a></h3>
-          <p>Thirteen complete, real-world workflows running interactively in the browser — sales dashboards, stock returns, A/B tests, web analytics, league tables, and more.</p>
+          <p>Sixteen complete, real-world workflows running interactively in the browser — sales dashboards, stock returns, A/B tests, web analytics, revenue waterfalls, SLA control towers, and more.</p>
           <div class="status done">✅ New — start here</div>
         </div>
       </div>

--- a/tests/playground.test.ts
+++ b/tests/playground.test.ts
@@ -40,6 +40,9 @@ const REAL_WORLD_EXAMPLE_PAGES = [
   "example_marketplace_fraud.html",
   "example_inventory_replenishment.html",
   "example_marketing_attribution.html",
+  "example_subscription_revenue_waterfall.html",
+  "example_fulfillment_sla.html",
+  "example_energy_anomaly_monitoring.html",
 ] as const;
 
 function listPlaygroundHtmlFiles(): string[] {


### PR DESCRIPTION
## Summary
- add three multi-section real-world examples for subscription revenue, fulfillment SLA operations, and energy anomaly monitoring
- link the new scenarios from the examples gallery and update the landing-page workflow count
- extend playground conformance coverage for the new complex example pages

## Validation
- `/Users/mrjf/.bun/bin/bun test ./tests/playground.test.ts`
- `/Users/mrjf/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 scripts/validate-python-examples.py playground`
- focused Playwright smoke test for the 3 new pages using system Chrome

Note: `bun run test:e2e` could not run in this checkout because local `node_modules/playwright` is not installed; the focused browser smoke used the bundled Playwright package instead.
